### PR TITLE
Hide empty tooltip

### DIFF
--- a/docs/leaflet-draw-latest.html
+++ b/docs/leaflet-draw-latest.html
@@ -1351,9 +1351,10 @@ Triggered when the user has finished removing shapes (remove mode) and saves.</t
 		<td></td>
 	</tr>
 	<tr id='l-geometryutil-readablearea'>
-		<td><code><b>readableArea</b>(<i>area</i>, <i>isMetric</i>)</nobr></code></td>
+		<td><code><b>readableArea</b>(<i>area</i>, <i>isMetric</i>, <i>precision</i>)</nobr></code></td>
 		<td><code>string</code></td>
-		<td><p>Returns a readable area string in yards or metric</p>
+		<td><p>Returns a readable area string in yards or metric.
+The value will be rounded as defined by the precision option object.</p>
 </td>
 	</tr>
 	<tr id='l-geometryutil-readabledistance'>
@@ -1363,9 +1364,10 @@ Triggered when the user has finished removing shapes (remove mode) and saves.</t
 </td>
 	</tr>
 	<tr id='l-geometryutil-readabledistance'>
-		<td><code><b>readableDistance</b>(<i>distance</i>, <i>isMetric</i>, <i>useFeet</i>, <i>isNauticalMile</i>)</nobr></code></td>
+		<td><code><b>readableDistance</b>(<i>distance</i>, <i>isMetric</i>, <i>useFeet</i>, <i>isNauticalMile</i>, <i>precision</i>)</nobr></code></td>
 		<td><code>string</code></td>
-		<td><p>Converts metric distance to distance string.</p>
+		<td><p>Converts metric distance to distance string.
+The value will be rounded as defined by the precision option object.</p>
 </td>
 	</tr>
 </tbody></table>

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -64,6 +64,11 @@ L.Draw.Tooltip = L.Class.extend({
 			'<span class="leaflet-draw-tooltip-subtext">' + labelText.subtext + '</span>' + '<br />' : '') +
 			'<span>' + labelText.text + '</span>';
 
+		// Hide the tooltip if it is empty
+		if (!labelText.text && !labelText.subtext) {
+			this._container.style.visibility = 'hidden';
+		}
+
 		return this;
 	},
 

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -61,11 +61,11 @@ L.Draw.Tooltip = L.Class.extend({
 
 		this._container.innerHTML =
 			(labelText.subtext.length > 0 ?
-			'<span class="leaflet-draw-tooltip-subtext">' + labelText.subtext + '</span>' + '<br />' : '') +
-			'<span>' + labelText.text + '</span>';
+				'<span class="leaflet-draw-tooltip-subtext">' + labelText.subtext + '</span>' + '<br />' : '') +
+			(labelText.text.length > 0 ?
+				'<span>' + labelText.text + '</span>' : '');
 
-		// Hide the tooltip if it is empty
-		if (!labelText.text && !labelText.subtext) {
+		if (!this._container.innerHTML.length) {
 			this._container.style.visibility = 'hidden';
 		}
 
@@ -78,9 +78,12 @@ L.Draw.Tooltip = L.Class.extend({
 		var pos = this._map.latLngToLayerPoint(latlng),
 			tooltipContainer = this._container;
 
-		if (this._container) {
+		// Only show the tooltip if it has content
+		if (this._container && this._container.innerHTML.length > 0) {
 			tooltipContainer.style.visibility = 'inherit';
 			L.DomUtil.setPosition(tooltipContainer, pos);
+		} else {
+			this._container.style.visibility = 'hidden';
 		}
 
 		return this;


### PR DESCRIPTION
If a tooltip has no content it will now not be shown, instead of having a very tiny and empty tooltip hovering besides your mouse.
This enables users to change localized texts to empty strings, in order to disable certain messages and even complete tooltips.